### PR TITLE
Add jr east to compatibility

### DIFF
--- a/content/software_other/pc/jreasttrainsimulator/_index.md
+++ b/content/software_other/pc/jreasttrainsimulator/_index.md
@@ -1,0 +1,6 @@
+---
+title: "JR EAST Train Simulator"
+weight: 2
+---
+
+{{% software-page "pc_jreasttrainsimulator" %}}

--- a/data/controllers.yml
+++ b/data/controllers.yml
@@ -136,7 +136,6 @@ vok00106:
   code: "VOK-00106"
   ref: "/controllers/serial/vok00106"
 
-
 zkns001:
   name: "One handle controller (Nintendo Switch)"
   date: 2021-08-05

--- a/data/software.yml
+++ b/data/software.yml
@@ -492,7 +492,6 @@ ps4_japankyoto:
       unofficial: yes
       adapter: titan
 
-
 pc_trainsim:
   name: "Train Simulator"
   date: 1995-08-19
@@ -640,6 +639,15 @@ pc_japanmeitetsu:
   platform: pc
   url: "https://store.steampowered.com/app/2281540/Japanese_Rail_Sim_Operating_the_MEITETSU_Line/"
   ref: "/software_other/pc/japanmeitetsu"
+  controllers:
+    - model: zkns001
+
+pc_jreasttrainsimulator:
+  name: "JR EAST Train Simulator"
+  date: 2022-11-15
+  platform: pc
+  url: "https://store.steampowered.com/app/2111630/JR_EAST_Train_Simulator/"
+  ref: "/software_other/pc/jreasttrainsimulator"
   controllers:
     - model: zkns001
 


### PR DESCRIPTION
Hey!

I've created this PR since JR East Train Simulator on the PC now has official Zuiki controller support.

Thanks
